### PR TITLE
Set stream=True for several file download APIs

### DIFF
--- a/kagglesdk/competitions/types/competition_api_service.py
+++ b/kagglesdk/competitions/types/competition_api_service.py
@@ -680,6 +680,10 @@ class ApiDownloadDataFileRequest(KaggleObject):
   def endpoint_path():
     return '/api/v1/competitions/data/download/{competition_name}/{file_name}'
 
+  @staticmethod
+  def stream():
+    return True
+
 
 class ApiDownloadDataFilesRequest(KaggleObject):
   r"""
@@ -713,6 +717,10 @@ class ApiDownloadDataFilesRequest(KaggleObject):
   @staticmethod
   def endpoint_path():
     return '/api/v1/competitions/data/download-all/{competition_name}'
+
+  @staticmethod
+  def stream():
+    return True
 
 
 class ApiDownloadLeaderboardRequest(KaggleObject):
@@ -2238,4 +2246,3 @@ ApiDataFile._fields = [
   FieldMetadata("url", "url", "_url", str, None, PredefinedSerializer(), optional=True),
   FieldMetadata("creationDate", "creation_date", "_creation_date", datetime, None, DateTimeSerializer()),
 ]
-

--- a/kagglesdk/datasets/types/dataset_api_service.py
+++ b/kagglesdk/datasets/types/dataset_api_service.py
@@ -1622,6 +1622,10 @@ class ApiDownloadDatasetRequest(KaggleObject):
   def endpoint_path():
     return '/api/v1/datasets/download/{owner_slug}/{dataset_slug}'
 
+  @staticmethod
+  def stream():
+    return True
+
 
 class ApiGetDatasetMetadataRequest(KaggleObject):
   r"""
@@ -3054,4 +3058,3 @@ ApiUploadDirectoryInfo._fields = [
   FieldMetadata("directories", "directories", "_directories", ApiUploadDirectoryInfo, [], ListSerializer(KaggleObjectSerializer())),
   FieldMetadata("files", "files", "_files", ApiDatasetNewFile, [], ListSerializer(KaggleObjectSerializer())),
 ]
-

--- a/kagglesdk/kaggle_http_client.py
+++ b/kagglesdk/kaggle_http_client.py
@@ -81,7 +81,7 @@ class KaggleHttpClient(object):
         http_request = self._prepare_request(service_name, request_name, request)
 
         # Merge environment settings into session
-        settings = self._session.merge_environment_settings(http_request.url, {}, None, None, None)
+        settings = self._session.merge_environment_settings(http_request.url, {}, request.stream(), None, None)
         http_response = self._session.send(http_request, **settings)
 
         response = self._prepare_response(response_type, http_response)

--- a/kagglesdk/kaggle_object.py
+++ b/kagglesdk/kaggle_object.py
@@ -286,6 +286,10 @@ class KaggleObject(object):
     def method():
         return "GET"
 
+    @staticmethod
+    def stream():
+        return False
+
     def _freeze(self):
         self._is_frozen = True
 


### PR DESCRIPTION
Fix #10

Here, `stream` is defined as a static method, similar to `method`, assuming it's fixed per API.  
If the `stream` is need to be changed dynamically, it might be more appropriate to define it as a property instead.

It would be appreciated if you could review this.