### PR TITLE
Cloud Build Release Script for kagglesdk

### DIFF
--- a/tools/cicd/Dockerfile
+++ b/tools/cicd/Dockerfile
@@ -1,0 +1,11 @@
+# This Docker image is a modified version of the python image including
+# a few necessary packages for building and publishing this library.
+ARG PYTHON_VERSION
+
+FROM python:${PYTHON_VERSION}
+
+RUN python -m pip install --upgrade pip
+
+RUN python -m pip install build==1.3.0 twine==6.2.0
+
+ENTRYPOINT ["python3"]

--- a/tools/cicd/cloudbuild.yaml
+++ b/tools/cicd/cloudbuild.yaml
@@ -1,0 +1,36 @@
+# To create a new cicd Docker image: 
+# cd path/to/kagglesdk
+# gcloud builds submit --project=kaggle-cicd --config=tools/cicd/cloudbuild.yaml .
+steps:
+
+# Import builder if exists.
+# Note: the reason to use bash is to be able to return an exit code 0 even if
+# the docker image doesn't exist yet.
+- name: 'gcr.io/cloud-builders/docker'
+  id: 'pull-image'
+  entrypoint: 'bash'
+  args:
+  - '-c'
+  - |
+    docker pull us-docker.pkg.dev/$PROJECT_ID/tools/kagglesdk-cicd:${_PYTHON_VERSION} || exit 0
+
+# Build an image for our release pipeline.
+# Use the previous built image as cache.
+- name: 'gcr.io/cloud-builders/docker'
+  id: 'build-image'
+  args:
+  - build
+  - -f
+  - Dockerfile
+  - -t
+  - us-docker.pkg.dev/$PROJECT_ID/tools/kagglesdk-cicd:${_PYTHON_VERSION}
+  - --cache-from
+  - us-docker.pkg.dev/$PROJECT_ID/tools/kagglesdk-cicd:${_PYTHON_VERSION}
+  - --build-arg
+  - PYTHON_VERSION=${_PYTHON_VERSION}
+  - .
+
+images: ['us-docker.pkg.dev/$PROJECT_ID/tools/kagglesdk-cicd']
+
+substitutions:
+  _PYTHON_VERSION: 3.10.13

--- a/tools/release/cloudbuild.yaml
+++ b/tools/release/cloudbuild.yaml
@@ -1,0 +1,102 @@
+# To run, follow instructions at: https://g3doc.corp.google.com/cloud/kaggle/apis/g3doc/kagglesdk.md#how-to-push-to-pypi
+steps:
+
+# Get the GitHub access token from Secret Manager.
+# The token is used to talk to GitHub API, specifically to create a release.
+- name: gcr.io/cloud-builders/gcloud
+  id: 'github-token'
+  entrypoint: 'bash'
+  args: 
+  - '-c'
+  - 'gcloud secrets versions access latest --secret=kaggleteam-github-access-token > /root/github_token'
+  volumes:
+  - name: 'root'
+    path: /root
+
+# Get the pypi password from Secret Manager, and create the ~/.pypirc file.
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: create-credentials-pypirc
+  entrypoint: 'bash'
+  args:
+    - '-c'
+    - |
+      token_test=$(gcloud secrets versions access latest --secret=test-pypi-token)
+      token=$(gcloud secrets versions access latest --secret=pypi-token)
+      cat >~/.pypirc <<EOL
+      [distutils]
+      index-servers =
+        pypi
+        pypitest
+      [pypi]
+      repository: https://upload.pypi.org/legacy/
+      username=__token__
+      password=${token}
+      [pypitest]
+      repository: https://test.pypi.org/legacy/
+      username=__token__
+      password=${token_test}
+      EOL
+  volumes:
+  - name: 'root'
+    path: /root
+
+# The kagglesdk-cicd Docker image is built from the tools/cicd/cloudbuild.yaml build.
+- name: us-docker.pkg.dev/$PROJECT_ID/tools/kagglesdk-cicd:${_PYTHON_VERSION}
+  id: build
+  waitFor: ['-']  # The '-' indicates that this step begins immediately.
+  entrypoint: 'bash'
+  args:
+  - '-c'
+  - |
+    python3 -m build --sdist
+    python3 -m build --wheel
+
+# Create a release on GitHub.
+# The `hub` image has been built previously in the project:
+# $ git clone https://github.com/GoogleCloudPlatform/cloud-builders-community.git
+# $ cd cloud-builders-community/hub
+# $ gcloud builds submit
+- name: 'us-docker.pkg.dev/$PROJECT_ID/tools/hub'
+  id: 'release'
+  waitFor: ['build']
+  entrypoint: 'bash'
+  env:
+  - GITHUB_USER=kaggle
+  - GITHUB_REPOSITORY=kagglesdk
+  - HUB_PROTOCOL=https
+  args:
+  - '-c'
+  # $$RELEASE_VERSION (two '$') is not a typo. This is to avoid conflicts with Google Cloud Build substitutions.
+  - |
+    export RELEASE_VERSION=`grep __version__ kagglesdk/__init__.py | sed -E "s/.*['\"]([^'\"]+)['\"].*/\1/"`
+    echo "Preparing release for version $$RELEASE_VERSION"
+    export GITHUB_TOKEN=$(</root/github_token)
+    if [ "${_PYPY_REPOSITORY}" = "pypi" ]; then
+      echo "Creating a release on GitHub..."
+      git clone https://github.com/kaggle/kagglesdk.git release-repo
+      cd release-repo
+      hub release create -m "release v$$RELEASE_VERSION" "v$$RELEASE_VERSION"
+    else
+      echo "Skipping GitHub release, this is a release to pypitest"
+    fi
+  volumes:
+  - name: 'root'
+    path: /root
+
+# Release package to pypi.
+- name: us-docker.pkg.dev/$PROJECT_ID/tools/kagglesdk-cicd:${_PYTHON_VERSION}
+  id: release-pypi
+  waitFor: ['build']
+  entrypoint: bash 
+  args:
+  - '-c'
+  - |
+    twine upload dist/* --repository ${_PYPY_REPOSITORY}
+  volumes:
+  - name: 'root'
+    path: /root
+
+substitutions:
+  _PYPY_REPOSITORY: pypitest
+  # Before changing this, ensure there's a matching tag for our bre-built image. See tools/cicd/cloudbuild.yaml in this repo.
+  _PYTHON_VERSION: 3.10.13


### PR DESCRIPTION
- Build in a consistent environment (Python, build & twine versions). No need to install these packages locally
- Create a release tag on our GitHub repo.
- Push to Pypi: No need to mess with Pypi credentials.

Related CL to update the kagglesdk release documentation: cl/833471401

http://b/461500916