### PR TITLE
Sync changes (web endpoint) and release

### DIFF
--- a/kagglesdk/__init__.py
+++ b/kagglesdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.21"
+__version__ = "0.1.22"
 
 from kagglesdk.kaggle_client import KaggleClient
 from kagglesdk.kaggle_creds import KaggleCredentials

--- a/kagglesdk/kaggle_env.py
+++ b/kagglesdk/kaggle_env.py
@@ -35,6 +35,13 @@ def get_endpoint(env: KaggleEnv):
     return _env_to_endpoint[env]
 
 
+def get_web_endpoint(env: KaggleEnv):
+    # In PROD, the `api` subdomain is used which breaks link to detail pages.
+    if env == KaggleEnv.PROD:
+        return "https://kaggle.com"
+    return get_endpoint(env)
+
+
 def get_env():
     env = os.getenv("KAGGLE_API_ENVIRONMENT")
     if env is None or env == "PROD":


### PR DESCRIPTION
Next: fix URL returned by kagglehub to use the web endpoint when linking
to detail pages.

http://b/507122006