### PR TITLE
Add .gcloudignore

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,12 @@
+# Source control
+.git/
+.github/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+
+# Builds & related cache
+dist/
+.mypy_cache/
+.pytest_cache/
+.ruff_cache/


### PR DESCRIPTION
* Ensures we don't upload the local /dist folder (was accidentally publishing locally built versions) and other unnecessary folders.

Same as https://github.com/Kaggle/kaggle-cli/pull/1004