### PR TITLE
fix: parse whole-second protobuf duration strings like 0s

### DIFF
--- a/kaggle_object_tests.py
+++ b/kaggle_object_tests.py
@@ -25,6 +25,8 @@ from kagglesdk.kernels.types.kernels_types import (
     AccessBehavior,
     GetKernelListDetailsRequest,
 )
+from kagglesdk.kaggle_object import TimeDeltaSerializer
+from kagglesdk.kernels.types.kernels_api_service import ApiGetAcceleratorQuotaStatisticsResponse
 
 Selector = ListCompetitionsRequest.Selector
 
@@ -568,6 +570,32 @@ class BackgroundOperationTests(unittest.TestCase):
         self.assertEqual("", operation.error)
         self.assertTrue("progress" in operation)
         self.assertEqual("90%", operation.progress)
+
+
+class TimeDeltaSerializerTests(unittest.TestCase):
+
+    def test_whole_second_duration(self):
+        self.assertEqual(TimeDeltaSerializer._from_dict_value("0s"), datetime.timedelta(0))
+        self.assertEqual(
+            TimeDeltaSerializer._from_dict_value("151s"),
+            datetime.timedelta(seconds=151),
+        )
+
+    def test_fractional_second_duration(self):
+        self.assertEqual(
+            TimeDeltaSerializer._from_dict_value("151.500s"),
+            datetime.timedelta(seconds=151, microseconds=500000),
+        )
+
+    def test_quota_response_deserializes_whole_second_durations(self):
+        response = ApiGetAcceleratorQuotaStatisticsResponse.from_json(
+            '{"gpuQuota":{"timeUsed":"0s","totalTimeAllowed":"151s"}}'
+        )
+        self.assertEqual(response.gpu_quota.time_used, datetime.timedelta(0))
+        self.assertEqual(
+            response.gpu_quota.total_time_allowed,
+            datetime.timedelta(seconds=151),
+        )
 
 
 if __name__ == "__main__":

--- a/kagglesdk/kaggle_object.py
+++ b/kagglesdk/kaggle_object.py
@@ -179,7 +179,10 @@ class TimeDeltaSerializer(ObjectSerializer):
 
     @staticmethod
     def _from_dict_value(value):
-        (seconds, nanosRaw) = value.rstrip("s").split(".")
+        raw_value = value.rstrip("s")
+        if "." not in raw_value:
+            return timedelta(seconds=int(raw_value))
+        seconds, nanosRaw = raw_value.split(".", 1)
         nanos = int(nanosRaw) * TimeDeltaSerializer.SUBSECOND_SCALING_FACTORS[len(nanosRaw)]
         return timedelta(seconds=int(seconds), microseconds=int(int(nanos) / 1000))
 


### PR DESCRIPTION
## Summary

Fix `TimeDeltaSerializer._from_dict_value` to accept protobuf JSON duration strings without a fractional component (e.g. `0s`, `151s`). The current implementation always splits on `.`, which crashes quota and other API responses that return whole-second durations.

**Needs manual sync with the kapigen base.**

## Root cause

```python
(seconds, nanosRaw) = value.rstrip("s").split(".")
```

Protobuf JSON allows whole-second values like `0s`. When `.split(".")` returns one element, unpacking fails with `ValueError: not enough values to unpack (expected 2, got 1)`.

Reported in Kaggle/kaggle-cli#1064.

## Tests

Added `TimeDeltaSerializerTests` in `kaggle_object_tests.py`:
- whole-second durations (`0s`, `151s`)
- fractional durations (`151.500s`) regression
- `ApiGetAcceleratorQuotaStatisticsResponse` JSON deserialization

## Test plan

- [x] `TimeDeltaSerializer._from_dict_value("0s")` returns `timedelta(0)`
- [ ] CI: `python -m unittest kaggle_object_tests.TimeDeltaSerializerTests`
