### PR TITLE
[codex] Add generated SDK import smoke test

### DIFF
--- a/tests/test_import_smoke.py
+++ b/tests/test_import_smoke.py
@@ -1,0 +1,53 @@
+import importlib
+import pkgutil
+import unittest
+
+
+class ImportSmokeTest(unittest.TestCase):
+    def test_all_kagglesdk_modules_import(self):
+        kagglesdk = importlib.import_module("kagglesdk")
+        failures = []
+
+        for module in pkgutil.walk_packages(kagglesdk.__path__, kagglesdk.__name__ + "."):
+            try:
+                importlib.import_module(module.name)
+            except Exception as exc:
+                failures.append(f"{module.name}: {type(exc).__name__}: {exc}")
+
+        self.assertEqual([], failures)
+
+    def test_kaggle_client_instantiates_with_subclients(self):
+        module = importlib.import_module("kagglesdk")
+        KaggleClient = module.KaggleClient
+        client = KaggleClient()
+        expected_groups = (
+            "admin",
+            "agents",
+            "benchmarks",
+            "blobs",
+            "common",
+            "competitions",
+            "datasets",
+            "discussions",
+            "education",
+            "kernels",
+            "models",
+            "search",
+            "security",
+            "users",
+        )
+
+        missing = [name for name in expected_groups if not hasattr(client, name)]
+        self.assertEqual([], missing)
+
+        subclient_count = sum(
+            1
+            for group_name in expected_groups
+            for attr_name in vars(getattr(client, group_name))
+            if attr_name.endswith("_client")
+        )
+        self.assertEqual(21, subclient_count)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a lightweight unittest smoke test for generated SDK import integrity.

The test verifies that:

- `import kagglesdk` succeeds
- every discovered `kagglesdk.*` module imports cleanly
- `KaggleClient()` instantiates
- the expected top-level client groups are present
- the generated client exposes 21 nested `*_client` subclients

## Why

The 0.1.31/0.1.32 import regression was caused by generated files referencing modules that were not included in the synced/published package. A build-only release step can still succeed in that case because wheel construction does not import the full transitive module graph.

This gives the release flow a cheap import-closure check that catches missing generated modules before publishing.

## Evidence

Current `main` plus this test fails in a fresh Python 3.13 venv after `pip install -e .`:

```text
ModuleNotFoundError: No module named 'kagglesdk.competitions.legacy'

Ran 2 tests in 1.218s
FAILED (errors=2)
```

The same test overlaid onto `origin/fix-imports-0.1.33` passes in a fresh Python 3.13 venv after `pip install -e .`:

```text
Ran 2 tests in 1.852s
OK
```

Commands used:

```bash
/opt/homebrew/bin/python3 -m venv .venv
.venv/bin/python -m pip install -q --upgrade pip
.venv/bin/python -m pip install -q -e .
.venv/bin/python -m unittest tests.test_import_smoke
```
