### PR TITLE
Add generated SDK import smoke test

### DIFF
--- a/tests/test_import_smoke.py
+++ b/tests/test_import_smoke.py
@@ -1,0 +1,53 @@
+import importlib
+import pkgutil
+import unittest
+
+
+class ImportSmokeTest(unittest.TestCase):
+    def test_all_kagglesdk_modules_import(self):
+        kagglesdk = importlib.import_module("kagglesdk")
+        failures = []
+
+        for module in pkgutil.walk_packages(kagglesdk.__path__, kagglesdk.__name__ + "."):
+            try:
+                importlib.import_module(module.name)
+            except Exception as exc:
+                failures.append(f"{module.name}: {type(exc).__name__}: {exc}")
+
+        self.assertEqual([], failures)
+
+    def test_kaggle_client_instantiates_with_subclients(self):
+        module = importlib.import_module("kagglesdk")
+        KaggleClient = module.KaggleClient
+        client = KaggleClient()
+        expected_groups = (
+            "admin",
+            "agents",
+            "benchmarks",
+            "blobs",
+            "common",
+            "competitions",
+            "datasets",
+            "discussions",
+            "education",
+            "kernels",
+            "models",
+            "search",
+            "security",
+            "users",
+        )
+
+        missing = [name for name in expected_groups if not hasattr(client, name)]
+        self.assertEqual([], missing)
+
+        subclient_count = sum(
+            1
+            for group_name in expected_groups
+            for attr_name in vars(getattr(client, group_name))
+            if attr_name.endswith("_client")
+        )
+        self.assertEqual(21, subclient_count)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a lightweight unittest smoke test for generated SDK import integrity.

The test verifies that:

- `import kagglesdk` succeeds
- every discovered `kagglesdk.*` module imports cleanly
- `KaggleClient()` instantiates
- the expected top-level client groups are present
- the generated client exposes 21 nested `*_client` subclients

## Why

The 0.1.31/0.1.32 import regression was caused by generated files referencing modules that were not included in the synced/published package. A build-only release step can still succeed in that case because wheel construction does not import the full transitive module graph.

This gives the release flow a cheap import-closure check that catches missing generated modules before publishing.

## Evidence

Current `main` plus this test fails after installing the project into a fresh environment:

```text
ModuleNotFoundError: No module named 'kagglesdk.competitions.legacy'

Ran 2 tests in 1.218s
FAILED (errors=2)
```

The same test overlaid onto `origin/fix-imports-0.1.33` passes:

```text
Ran 2 tests in 1.852s
OK
```

## Reproduction commands

Run the test on this branch, which is based on current `main` and demonstrates the missing-import failure:

```bash
git fetch origin
git checkout import-smoke-test
uv run --with-editable . python -m unittest tests.test_import_smoke
```

Run the exact same test against the 0.1.33 fix branch by saving this PR's test file before switching branches:

```bash
cp tests/test_import_smoke.py /tmp/test_import_smoke.py
git checkout origin/fix-imports-0.1.33
mkdir -p tests
cp /tmp/test_import_smoke.py tests/test_import_smoke.py
uv run --with-editable . python -m unittest tests.test_import_smoke
rm /tmp/test_import_smoke.py
```
